### PR TITLE
Updating installation setup and setup.py

### DIFF
--- a/installation_guide.md
+++ b/installation_guide.md
@@ -44,7 +44,7 @@ conda activate paddlehelix
 conda install -c conda-forge rdkit
 ```
 5. Install `paddle` base on your choice of GPU/CPU version:
-you can check paddlepaddle's [official document][https://www.paddlepaddle.org.cn/documentation/docs/en/2.0-rc1/install/index_en.html ] to install paddle2.0
+you can check paddlepaddle's [official document](https://www.paddlepaddle.org.cn/documentation/docs/en/2.0-rc1/install/index_en.html) to install paddle2.0
 
 
 6. Install `PGL` using pip:

--- a/installation_guide.md
+++ b/installation_guide.md
@@ -44,7 +44,8 @@ conda activate paddlehelix
 conda install -c conda-forge rdkit
 ```
 5. Install `paddle` base on your choice of GPU/CPU version:
-you can check paddlepaddle's [official document](https://www.paddlepaddle.org.cn/documentation/docs/en/2.0-rc1/install/index_en.html) to install paddle2.0
+
+    check paddlepaddle's [official document](https://www.paddlepaddle.org.cn/documentation/docs/en/2.0-rc1/install/index_en.html) to install paddle2.0
 
 
 6. Install `PGL` using pip:

--- a/installation_guide.md
+++ b/installation_guide.md
@@ -43,17 +43,27 @@ conda activate paddlehelix
 ```bash
 conda install -c conda-forge rdkit
 ```
-5. Install PaddleHelix using pip:
+5. Install `paddle` base on your choice of GPU/CPU version:
+you can check paddlepaddle's [official document][https://www.paddlepaddle.org.cn/documentation/docs/en/2.0-rc1/install/index_en.html ] to install paddle2.0
+
+
+6. Install `PGL` using pip:
+   
+```bash
+pip install pgl
+```
+
+7. Install `PaddleHelix` using pip:
 
 ```bash
 pip install paddlehelix
 ```
 
-6. The installation is done!
+8. The installation is done!
 
 
-> If you want to deactivate the conda environment, do this:
-> 
-> ```bash
-> conda deactivate
-> ```
+9. If you want to deactivate the conda environment, do this:
+
+ ```bash
+ conda deactivate
+ ```

--- a/installation_guide.md
+++ b/installation_guide.md
@@ -63,7 +63,7 @@ pip install paddlehelix
 8. The installation is done!
 
 
-9. If you want to deactivate the conda environment, do this:
+9. After runing the project, if you want to deactivate the conda environment, do this:
 
  ```bash
  conda deactivate

--- a/installation_guide_cn.md
+++ b/installation_guide_cn.md
@@ -43,7 +43,8 @@ conda activate paddlehelix
 conda install -c conda-forge rdkit
 ```
 5. 此外需要基于你对CPU/GPU版本的选择来安装`paddle`:
-   可以参看官网的[安装文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.0-rc1/install/index_cn.html)来进行安装paddle2.0
+
+   参看paddle[官方文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.0-rc1/install/index_cn.html)安装
 
    
    

--- a/installation_guide_cn.md
+++ b/installation_guide_cn.md
@@ -38,18 +38,30 @@ conda create -n paddlehelix python=3.7
 conda activate paddlehelix
 ```
 
-4. 在安装 PaddleHelix 之前，首先需要使用 conda 安装 rdkit：
+4. 在安装 PaddleHelix 之前，首先需要使用 conda 安装 `rdkit`：
 ```bash
 conda install -c conda-forge rdkit
 ```
-5. 等待 rdkit 安装完成，之后使用 pip 命令安装 PaddleHelix
+5. 此外需要基于你对CPU/GPU版本的选择来安装`paddle`:
+   可以参看官网的[安装文档][https://www.paddlepaddle.org.cn/documentation/docs/zh/2.0-rc1/install/index_cn.html]来进行安装paddle2.0
+
+   
+   
+6. 使用pip命令安装`PGL`:
+```bash
+pip insatll pgl
+```
+
+7. 使用 pip 命令安装 PaddleHelix
 ```bash
 pip install paddlehelix
 ```
 
-6. 等待 PaddleHelix 安装完成！
+8. 等待 PaddleHelix 安装完成！
 
->如果想要退出当前 conda 环境，可以使用下列命令：
->```bash
->conda deactivate
->```
+
+9. 如果想要退出当前 conda 环境，可以使用下列命令：
+```bash
+conda deactivate
+```
+

--- a/installation_guide_cn.md
+++ b/installation_guide_cn.md
@@ -53,7 +53,7 @@ conda install -c conda-forge rdkit
 pip insatll pgl
 ```
 
-7. 使用 pip 命令安装 PaddleHelix
+7. 使用 pip 命令安装 `PaddleHelix`
 ```bash
 pip install paddlehelix
 ```

--- a/installation_guide_cn.md
+++ b/installation_guide_cn.md
@@ -43,7 +43,7 @@ conda activate paddlehelix
 conda install -c conda-forge rdkit
 ```
 5. 此外需要基于你对CPU/GPU版本的选择来安装`paddle`:
-   可以参看官网的[安装文档][https://www.paddlepaddle.org.cn/documentation/docs/zh/2.0-rc1/install/index_cn.html]来进行安装paddle2.0
+   可以参看官网的[安装文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.0-rc1/install/index_cn.html)来进行安装paddle2.0
 
    
    

--- a/installation_guide_cn.md
+++ b/installation_guide_cn.md
@@ -61,7 +61,7 @@ pip install paddlehelix
 8. 等待 PaddleHelix 安装完成！
 
 
-9. 如果想要退出当前 conda 环境，可以使用下列命令：
+9. 运行完项目之后,如果想要退出当前 conda 环境，可以使用下列命令：
 ```bash
 conda deactivate
 ```

--- a/pahelix/__init__.py
+++ b/pahelix/__init__.py
@@ -16,7 +16,6 @@
 Initialize.
 """
 
-from warnings import warn
 def get_fluid_version():
     import paddle
     paddle_version = int(paddle.__version__.replace('.', '').split('-')[0])

--- a/pahelix/__init__.py
+++ b/pahelix/__init__.py
@@ -16,3 +16,12 @@
 Initialize.
 """
 
+from warnings import warn
+def get_fluid_version():
+    import paddle
+    paddle_version = int(paddle.__version__.replace('.', '').split('-')[0])
+    return paddle_version
+
+paddle_version = get_fluid_version()
+if paddle_version <200:
+    print('Warning:\n \tYou are using paddle version less than 2.0.0, which will cause errors during the execution.\n \t To avoid that, please use paddle version >= 2.0.0rc0')

--- a/setup.py
+++ b/setup.py
@@ -116,17 +116,15 @@ requires = [
 'numpy',
 'pandas',
 'networkx',
-'pgl>=1.2.0',
-'paddlepaddle>=2.0.0-rc0',
 "sklearn",
 ]
 
 setup(
     name="paddlehelix",
-    version="1.0.0a0",
+    version="1.0.0b",
     author="fangxiaomin",
     author_email="fangxiaomin01@baidu.com",
-    description="",
+    description="Adding version check",
     long_description="",
     packages = find_packages(),
     ext_modules=[CMakeExtension("linear_rna")],


### PR DESCRIPTION
Remove the install_requirements of paddlepaddle version and pgl, adding instructions to install both packages to the installation readme. And add checking function to the __init__ of the pahelix, if the user import pahelix with a paddle version less than 2.0.0rc0, a waring will be printed on the screen.