### PR TITLE
Optimize the implementation of StructureModule.

### DIFF
--- a/apps/protein_folding/helixfold/alphafold_paddle/model/r3.py
+++ b/apps/protein_folding/helixfold/alphafold_paddle/model/r3.py
@@ -432,8 +432,10 @@ def rots_mul_rots(a: Rots, b: Rots) -> Rots:
     # c1 = rots_mul_vecs(a, Vecs(b.xy, b.yy, b.zy))
     # c2 = rots_mul_vecs(a, Vecs(b.xz, b.yz, b.zz))
     # return Rots(c0.x, c1.x, c2.x, c0.y, c1.y, c2.y, c0.z, c1.z, c2.z)
-    if a.shape == b.shape:$
-        return Rots(paddle.matmul(a.rotation, b.rotation))
+    a_rot = a.rotation
+    b_rot = b.rotation
+    if a.shape == b.shape:
+        return Rots(paddle.matmul(a_rot, b_rot))
     else:
         out_shape = broadcast_shape(a_rot.shape, b_rot.shape)
         zeros = paddle.zeros(shape=out_shape, dtype=a_rot.dtype)

--- a/apps/protein_folding/helixfold/alphafold_paddle/model/r3.py
+++ b/apps/protein_folding/helixfold/alphafold_paddle/model/r3.py
@@ -428,10 +428,6 @@ def broadcast_shape(x_shape, y_shape):
 
 def rots_mul_rots(a: Rots, b: Rots) -> Rots:
     """Composition of rotations 'a' and 'b'."""
-    # c0 = rots_mul_vecs(a, Vecs(b.xx, b.yx, b.zx))
-    # c1 = rots_mul_vecs(a, Vecs(b.xy, b.yy, b.zy))
-    # c2 = rots_mul_vecs(a, Vecs(b.xz, b.yz, b.zz))
-    # return Rots(c0.x, c1.x, c2.x, c0.y, c1.y, c2.y, c0.z, c1.z, c2.z)
     a_rot = a.rotation
     b_rot = b.rotation
     if a.shape == b.shape:
@@ -453,9 +449,6 @@ def rots_mul_rots(a: Rots, b: Rots) -> Rots:
 
 def rots_mul_vecs(m: Rots, v: Vecs) -> Vecs:
     """Apply rotations 'm' to vectors 'v'."""
-    # return Vecs(m.xx * v.x + m.xy * v.y + m.xz * v.z,
-    #             m.yx * v.x + m.yy * v.y + m.yz * v.z,
-    #             m.zx * v.x + m.zy * v.y + m.zz * v.z)
     m_rot = m.rotation
     v_trans = v.translation
     if m_rot.shape[:-2] == v_trans.shape[:-1]:
@@ -499,7 +492,6 @@ def vecs_from_tensor(x: paddle.Tensor  # shape (..., 3)
                     ) -> Vecs:  # shape (...)
     """Converts from tensor of shape (3,) to Vecs."""
     assert x.shape[-1] == 3
-    #return Vecs(x[..., 0], x[..., 1], x[..., 2])
     return Vecs(x)
 
 


### PR DESCRIPTION
针对PR中的代码修改，我写了单测比较精度：https://gist.github.com/Xreki/f451fcb6c3dfe7d83d137b3f7c0ca3f1

收集了模型中`rots_mul_rots`和`rots_mul_vecs`输入输出的shape，发现主要存在2种配置。

- rots_mul_rots

| | a.shape | b.shape | out.shape | 说明 |
|---|---|---|---|---|
| 不需要广播 | [2, 256, 8, 3, 3] | [2, 256, 8, 3, 3] | [2, 256, 8, 3, 3] | 原始实现需要107个算子，PR修改后只需要1个算子 |
| 需要广播  | [2, 256, 1, 3, 3] | [2, 256, 8, 3, 3] | [2, 256, 8, 3, 3] | 原始实现需要107个算子，PR修改后只需要3个算子 |


- rots_mul_vecs

| | m.shape | v.shape | out.shape | 说明 |
|---|---|---|---|---|
| 不需要广播 | [2, 256, 14, 3, 3] | [2, 256, 14, 3] | [2, 256, 14, 3] | PR修改后只需要3个算子 |
| 需要广播 | [2, 256, 1, 3, 3] | [2, 256, 8, 3] | [2, 256, 8, 3] | PR修改后只需要5个算子 |
