### PR TITLE
Optimization for _multiply and _multiply_np in QuantAffine

### DIFF
--- a/apps/protein_folding/helixfold/alphafold_paddle/model/quat_affine.py
+++ b/apps/protein_folding/helixfold/alphafold_paddle/model/quat_affine.py
@@ -536,7 +536,6 @@ def make_canonical_transform_np(
     c2_rot_matrix = np.stack([np.array([cos_c2,  zeros, sin_c2]),
                               np.array([zeros,    ones,  zeros]),
                               np.array([-sin_c2, zeros, cos_c2])])
-    
     c_rot_matrix = np.matmul(c2_rot_matrix, c1_rot_matrix)
     n_xyz = np.stack(apply_rot_to_vec_np(c_rot_matrix, n_xyz, unstack=True)).T
 


### PR DESCRIPTION
修改内容通过了精度测试，精度无下降. 测试方法：在模型代码中加入以下测试代码，并训练模型
```
    c_rot_matrix = _multiply_np(c2_rot_matrix, c1_rot_matrix)
    c_rot_matrix1 = np.matmul(c2_rot_matrix, c1_rot_matrix)
    np.testing.assert_array_equal(c_rot_matrix, c_rot_matrix1)

    temp = np.transpose(np.matmul(n_rot_matrix, c_rot_matrix))
    temp1 = np.transpose(_multiply_np(n_rot_matrix, c_rot_matrix))
    np.testing.assert_array_equal(temp, c_rot_matrix1)
```