### PR TITLE
Fix dependency name for scikit-learn in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ requires = [
 'numpy',
 'pandas',
 'networkx',
-"sklearn",
+"scikit-learn",
 ]
 
 setup(


### PR DESCRIPTION

**Description:**

This pull request fixes an issue in `setup.py` where the scikit-learn dependency was incorrectly listed as `"sklearn"` instead of the correct name `"scikit-learn"`. This change ensures that the correct package is installed when setting up the project. 

**Changes Made:**

* Modified line 119 in `setup.py`:
    * Replaced `"sklearn"` with `"scikit-learn"` in the `requires` list.

**Reason for Change:**

The current dependency name `"sklearn"` is incorrect and will lead to failure when installing project dependencies. The correct package name for scikit-learn is `"scikit-learn"`.  `"sklearn"` has been deprecated, if we use this name, a runtime Error will raise(My env, ubuntu 20.04). This change ensures that the setup process installs the correct package.

**Test Coverage:**

This change does not affect the project's functionality and does not require additional testing.

**Additional Notes:**

None.
