### PR TITLE
Resolving Error in 'run_infer.sh' Script Due to Duplicate 'bfd_database_path' Argument

### DIFF
--- a/apps/protein_folding/helixfold3/README.md
+++ b/apps/protein_folding/helixfold3/README.md
@@ -147,7 +147,6 @@ CUDA_VISIBLE_DEVICES=0 "$PYTHON_BIN" inference.py \
     --preset='reduced_dbs' \
     --bfd_database_path "$DATA_DIR/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt" \
     --small_bfd_database_path "$DATA_DIR/small_bfd/bfd-first_non_consensus_sequences.fasta" \
-    --bfd_database_path "$DATA_DIR/small_bfd/bfd-first_non_consensus_sequences.fasta" \
     --uniclust30_database_path "$DATA_DIR/uniclust30/uniclust30_2018_08/uniclust30_2018_08" \
     --uniprot_database_path "$DATA_DIR/uniprot/uniprot.fasta" \
     --pdb_seqres_database_path "$DATA_DIR/pdb_seqres/pdb_seqres.txt" \

--- a/apps/protein_folding/helixfold3/run_infer.sh
+++ b/apps/protein_folding/helixfold3/run_infer.sh
@@ -19,7 +19,6 @@ CUDA_VISIBLE_DEVICES=0 "$PYTHON_BIN" inference.py \
     --preset='reduced_dbs' \
     --bfd_database_path "$DATA_DIR/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt" \
     --small_bfd_database_path "$DATA_DIR/small_bfd/bfd-first_non_consensus_sequences.fasta" \
-    --bfd_database_path "$DATA_DIR/small_bfd/bfd-first_non_consensus_sequences.fasta" \
     --uniclust30_database_path "$DATA_DIR/uniclust30/uniclust30_2018_08/uniclust30_2018_08" \
     --uniprot_database_path "$DATA_DIR/uniprot/uniprot.fasta" \
     --pdb_seqres_database_path "$DATA_DIR/pdb_seqres/pdb_seqres.txt" \


### PR DESCRIPTION
Hi there,
  I encountered a problem when running the 'run_infer.sh' script with '--preset' set to 'full_dbs'. The error message was: ValueError: Could not find HHBlits database ./data/small_bfd/bfd-first_non_consensus_sequences.fasta. I noticed that there were two identical arguments '--bfd_database_path' specified, and this issue could be fixed by deleting the duplicate line: --bfd_database_path "$DATA_DIR/small_bfd/bfd-first_non_consensus_sequences.fasta".